### PR TITLE
画像（favicon, ogp）が取得できなかったときの見た目の調整

### DIFF
--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -5,6 +5,25 @@ import { OgpData } from "@/types";
 interface LinkCardProps {
   ogp: OgpData;
 }
+export const Favicon: VFC<LinkCardProps> = ({ ogp }) => {
+  const { faviconUrl, pageUrl } = ogp;
+  return (
+    <div className="flex items-center">
+      {(() => {
+        if (faviconUrl) {
+          return (
+            <>
+              <img src={faviconUrl} className="h-6" alt="" />
+              <p className="text-base ml-2">{pageUrl}</p>
+            </>
+          );
+        } else {
+          return <p className="text-base ">{pageUrl}</p>;
+        }
+      })()}
+    </div>
+  );
+};
 
 export const LinkCard: VFC<LinkCardProps> = ({ ogp }) => {
   const { title, description, faviconUrl, pageUrl, ogImgUrl } = ogp;
@@ -12,17 +31,38 @@ export const LinkCard: VFC<LinkCardProps> = ({ ogp }) => {
   return (
     <a href={pageUrl} target="_blank" rel="noreferrer">
       <article className="flex justify-between border border-gray-400 border-solid rounded h-40">
-        <div className="flex flex-col justify-between p-5 w-3/5 hover:bg-gray-100 ">
-          <h3 className="text-2xl truncate">{title}</h3>
-          <p className="text-base text-gray-500 truncate">{description}</p>
-          <div className="flex items-center">
-            <img src={faviconUrl} className="h-6" alt="" />
-            <p className="text-base ml-2">{pageUrl}</p>
-          </div>
-        </div>
-        <div className="w-2/5 h-full rounded">
-          <img src={ogImgUrl} className="w-full h-full object-cover" alt="" />
-        </div>
+        {(() => {
+          if (ogImgUrl) {
+            return (
+              <>
+                <div className="flex flex-col justify-between p-5 w-3/5 hover:bg-gray-100 ">
+                  <h3 className="text-2xl truncate">{title}</h3>
+                  <p className="text-base text-gray-500 truncate">
+                    {description}
+                  </p>
+                  <Favicon ogp={ogp} />
+                </div>
+                <div className="w-2/5 h-full rounded">
+                  <img
+                    src={ogImgUrl}
+                    className="w-full h-full object-cover"
+                    alt=""
+                  />
+                </div>
+              </>
+            );
+          } else {
+            return (
+              <div className="flex flex-col justify-between p-5 w-full hover:bg-gray-100 ">
+                <h3 className="text-2xl truncate">{title}</h3>
+                <p className="text-base text-gray-500 truncate">
+                  {description}
+                </p>
+                <Favicon ogp={ogp} />
+              </div>
+            );
+          }
+        })()}
       </article>
     </a>
   );

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -5,64 +5,30 @@ import { OgpData } from "@/types";
 interface LinkCardProps {
   ogp: OgpData;
 }
-export const Favicon: VFC<LinkCardProps> = ({ ogp }) => {
-  const { faviconUrl, pageUrl } = ogp;
-  return (
-    <div className="flex items-center">
-      {(() => {
-        if (faviconUrl) {
-          return (
-            <>
-              <img src={faviconUrl} className="h-6" alt="" />
-              <p className="text-base ml-2">{pageUrl}</p>
-            </>
-          );
-        } else {
-          return <p className="text-base ">{pageUrl}</p>;
-        }
-      })()}
-    </div>
-  );
-};
 
 export const LinkCard: VFC<LinkCardProps> = ({ ogp }) => {
   const { title, description, faviconUrl, pageUrl, ogImgUrl } = ogp;
+  const w = ogImgUrl ? "w-3/5" : "w-full";
+  const ml = faviconUrl ? "ml-2" : "";
 
   return (
     <a href={pageUrl} target="_blank" rel="noreferrer">
       <article className="flex justify-between border border-gray-400 border-solid rounded h-40">
-        {(() => {
-          if (ogImgUrl) {
-            return (
-              <>
-                <div className="flex flex-col justify-between p-5 w-3/5 hover:bg-gray-100 ">
-                  <h3 className="text-2xl truncate">{title}</h3>
-                  <p className="text-base text-gray-500 truncate">
-                    {description}
-                  </p>
-                  <Favicon ogp={ogp} />
-                </div>
-                <div className="w-2/5 h-full rounded">
-                  <img
-                    src={ogImgUrl}
-                    className="w-full h-full object-cover"
-                    alt=""
-                  />
-                </div>
-              </>
-            );
-          } else {
-            return (
-              <div className="flex flex-col justify-between p-5 w-full hover:bg-gray-100 ">
-                <h3 className="text-2xl truncate">{title}</h3>
-                <p className="text-base text-gray-500 truncate">
-                  {description}
-                </p>
-                <Favicon ogp={ogp} />
-              </div>
-            );
-          }
-        })()}
+        <div
+          className={`flex flex-col justify-between p-5  hover:bg-gray-100 ${w}`}
+        >
+          <h3 className="text-2xl truncate">{title}</h3>
+          <p className="text-base text-gray-500 truncate">{description}</p>
+          <div className="flex items-center">
+            {faviconUrl && <img src={faviconUrl} className="h-6" alt="" />}
+            <p className={`text-base ${ml}`}>{pageUrl}</p>
+          </div>
+        </div>
+        {ogImgUrl && (
+          <div className="w-2/5 h-full rounded">
+            <img src={ogImgUrl} className="w-full h-full object-cover" alt="" />
+          </div>
+        )}
       </article>
     </a>
   );

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -8,10 +8,11 @@ interface LinkCardProps {
 
 export const LinkCard: VFC<LinkCardProps> = ({ ogp }) => {
   const { title, description, faviconUrl, pageUrl, ogImgUrl } = ogp;
+
   return (
     <a href={pageUrl} target="_blank" rel="noreferrer">
-      <article className="flex justify-between border border-gray-400 border-solid rounded">
-        <div className="flex flex-col justify-between p-5 w-3/5 hover:bg-gray-100">
+      <article className="flex justify-between border border-gray-400 border-solid rounded h-40">
+        <div className="flex flex-col justify-between p-5 w-3/5 hover:bg-gray-100 ">
           <h3 className="text-2xl truncate">{title}</h3>
           <p className="text-base text-gray-500 truncate">{description}</p>
           <div className="flex items-center">
@@ -19,8 +20,8 @@ export const LinkCard: VFC<LinkCardProps> = ({ ogp }) => {
             <p className="text-base ml-2">{pageUrl}</p>
           </div>
         </div>
-        <div className="w-2/5">
-          <img src={ogImgUrl} alt="" />
+        <div className="w-2/5 h-full rounded">
+          <img src={ogImgUrl} className="w-full h-full object-cover" alt="" />
         </div>
       </article>
     </a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,8 @@ export const mockOgpData2: OgpData = {
   title: "State as a Snapshot",
   description:
     "State variables might look like regular JavaScript variables that you can read and write to. However, state behaves more like a snapshot. Setting it does not change the state variable you already have, but instead triggers a re-render.",
-  faviconUrl: "https://beta.reactjs.org/favicon.ico",
-  pageUrl: "https://beta.reactjs.org/learn/state-as-a-snapshot",
-  ogImgUrl: "https://beta.reactjs.org/logo-og.png",
+  faviconUrl: "",
+  pageUrl: "",
+  ogImgUrl: "",
 };
 export const mockOgpDataList = [mockOgpData, mockOgpData1, mockOgpData2];

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export const mockOgpData2: OgpData = {
   description:
     "State variables might look like regular JavaScript variables that you can read and write to. However, state behaves more like a snapshot. Setting it does not change the state variable you already have, but instead triggers a re-render.",
   faviconUrl: "",
-  pageUrl: "",
+  pageUrl: "https://beta.reactjs.org/learn/state-as-a-snapshot",
   ogImgUrl: "",
 };
 export const mockOgpDataList = [mockOgpData, mockOgpData1, mockOgpData2];


### PR DESCRIPTION
#1 
# 実装内容
- ogpImgUrlが取得できなかった場合、左のブロック幅をarticleいっぱいにする（LinkCardコンポーネントのreturn内にif文追加）
- faviconUrlが取得できなかった場合、pageLinkを左揃えにする（Faviconコンポーネントを追加）
# 懸念点
- ogp={ogp}が重複
